### PR TITLE
ci: switch scraper from bvp/boatrace-scraper to bvp/scraper

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,14 +24,14 @@ jobs:
 
       - name: Install base dependencies (without scraper)
         run: |
-          composer remove bvp/boatrace-scraper --no-update || true
+          composer remove bvp/scraper --no-update || true
           composer install --no-interaction --no-progress
 
       - name: Require scraper version ^5.0
-        run: composer require bvp/boatrace-scraper:^5.0 --no-update
+        run: composer require bvp/scraper:^5.0 --no-update
 
       - name: Update lock file for scraper
-        run: composer update bvp/boatrace-scraper --with-dependencies
+        run: composer update bvp/scraper --with-dependencies
 
       - name: Final install
         run: composer install --prefer-dist --no-interaction --no-progress


### PR DESCRIPTION
[bvp/boatrace-scraper](https://packagist.org/packages/bvp/boatrace-scraper) は [bvp/scraper](https://packagist.org/packages/bvp/scraper) にリネームしているので追従しました。動作に影響は全くありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - CIの定期実行ワークフローでComposer関連コマンドのパッケージ名を新名称に更新し、削除・バージョン指定・ロック更新を整備。
  - 機能や挙動の変更はなく、インストール手順とスケジュール実行は従来通り動作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->