### PR TITLE
ci: update commit messages to follow Conventional Commits via GitHub Actions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -57,7 +57,7 @@ jobs:
           )
           if [ -n "$FILES" ]; then
             git add $FILES
-            git commit -m "chore: Deploy JSON file to docs/v2 [skip ci]" || true
+            git commit -m "chore: deploy JSON file to docs/v2 [skip ci]" || true
             git pull --rebase --autostash
             git push origin HEAD
           else


### PR DESCRIPTION
Conventional Commits に倣ってコミットメッセージの先頭を小文字に変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - CI の定期実行ワークフローで自動コミットメッセージの表記を微修正（"Deploy"→"deploy"）。
  - ワークフローの動作やデプロイ手順に変更はありません。
  - エンドユーザー向けの機能追加・修正はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->